### PR TITLE
Move create Stream functions to fsSyncMethods

### DIFF
--- a/src/util/lists.js
+++ b/src/util/lists.js
@@ -44,6 +44,9 @@ export const fsSyncMethods = [
     'accessSync',
     'fdatasyncSync',
     'mkdtempSync',
+
+    'createReadStream',
+    'createWriteStream',
 ];
 
 export const fsAsyncMethods = [
@@ -86,7 +89,4 @@ export const fsAsyncMethods = [
     'watchFile',
     'unwatchFile',
     'watch',
-
-    'createReadStream',
-    'createWriteStream',
 ];

--- a/src/util/lists.js
+++ b/src/util/lists.js
@@ -44,6 +44,7 @@ export const fsSyncMethods = [
     'accessSync',
     'fdatasyncSync',
     'mkdtempSync',
+    'copyFileSync',
 
     'createReadStream',
     'createWriteStream',
@@ -85,6 +86,7 @@ export const fsAsyncMethods = [
     'access',
     'fdatasync',
     'mkdtemp',
+    'copyFile',
 
     'watchFile',
     'unwatchFile',


### PR DESCRIPTION
Fixes https://github.com/streamich/unionfs/issues/92 (`createReadStream()` and `createWriteStream()` not working)

- Move create Stream functions to `fsSyncMethods` 
- Add copyFile and copyFileSync (added Node v8.5.0) 