### PR TITLE
Move demos folder

### DIFF
--- a/demo/fs-1.js
+++ b/demo/fs-1.js
@@ -1,5 +1,5 @@
-import {vol} from '../../../memfs/lib';
-import {patchFs} from '../index';
+import {vol} from 'memfs';
+import {patchFs} from 'fs-monkey';
 
 vol.fromJSON({'/dir/foo': 'bar'});
 patchFs(vol);

--- a/demo/require-1.js
+++ b/demo/require-1.js
@@ -1,5 +1,5 @@
-import {vol} from '../../../memfs/lib';
-import patchRequire from '../patchRequire';
+import {vol} from 'memfs';
+import {patchRequire} from 'fs-monkey';
 
 
 vol.fromJSON({'/foo/bar.js': 'console.log("obi trice");'});

--- a/demo/require-2.js
+++ b/demo/require-2.js
@@ -1,6 +1,6 @@
-import {vol} from '../../../memfs/lib';
-import patchRequire from '../patchRequire';
-const {ufs} = require('../../../unionfs/lib');
+import {vol} from 'memfs';
+import {patchRequire} from 'fs-monkey';
+import {ufs} from 'unionfs';
 import * as fs from 'fs';
 
 

--- a/demo/yolo-1.js
+++ b/demo/yolo-1.js
@@ -1,4 +1,4 @@
-import {patchFs} from '../index';
+import {patchFs} from 'fs-monkey';
 
 const myfs = {
     readFileSync: () => 'hello world',

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/index');

--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
     "monkeypatch",
     "patch"
   ],
+  "files": [
+    "lib",
+    "!lib/__tests__",
+    "docs"
+  ],
+  "directories": {
+    "doc": "docs"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/streamich/fs-monkey.git"

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import patchFs from './patchFs';
 import patchRequire from './patchRequire';
+import * as util from './util/list';
 
 export {
+    util,
     patchFs,
     patchRequire,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import patchFs from './patchFs';
 import patchRequire from './patchRequire';
+import { unixify } from './correctPath';
 import * as util from './util/list';
 
 export {
     util,
+    unixify,
     patchFs,
     patchRequire,
 };


### PR DESCRIPTION
Makes the package a lot smaller (from ~200kb to ~20kb), and exports `utils`/`lists` & `unixify` from the top-level, making it a bit nicer to import downstream.

`normalize-path` has had a refactor so it's just one single function, but I didn't want to mess with it for now, since it's stable 🤷‍♂ 