### PR TITLE
fix: adjust release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "babel src --out-dir lib",
     "test": "jest",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "babel src --out-dir lib",
     "test": "jest",
-    "semantic-release": "semantic-release"
+    "semantic-release": "npm run build && semantic-release"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
`semantic-release` has been failing ever since it was introduced, meaning that when the new change got released yesterday it actually published a package that was devoid of build 😬 

(ideally v0.4.0 should be unpublished, but 🤷‍♂)