### PR TITLE
Fix util import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import patchFs from './patchFs';
 import patchRequire from './patchRequire';
 import { unixify } from './correctPath';
-import * as util from './util/list';
+import * as util from './util/lists';
 
 export {
     util,


### PR DESCRIPTION
The import path for `util` is wrong and result in an error when using the package.

This fixes #192