### PR TITLE
fix: add `The Unlicense` license SDPX in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
       "@semantic-release/git"
     ]
   },
+  "license": "Unlicense",
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.js"


### PR DESCRIPTION
This is required by our ifra tooling to validate the license and allows us to consumed this package.