### PR TITLE
fix: add The Unlicense license SDPX in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Monkey patches for file system related things.",
   "main": "lib/index.js",
+  "license": "Unlicense",
   "keywords": [
     "fs",
     "file",


### PR DESCRIPTION
closes #230 
This is required by our infra tooling to validate the license compliance and allows us to consumed this package.