### PR TITLE
fix: add .rm and .rmSync to fs methods

### DIFF
--- a/src/util/lists.js
+++ b/src/util/lists.js
@@ -45,6 +45,7 @@ export const fsSyncMethods = [
     'fdatasyncSync',
     'mkdtempSync',
     'copyFileSync',
+    'rmSync',
 
     'createReadStream',
     'createWriteStream',
@@ -87,6 +88,7 @@ export const fsAsyncMethods = [
     'fdatasync',
     'mkdtemp',
     'copyFile',
+    'rm',
 
     'watchFile',
     'unwatchFile',


### PR DESCRIPTION
> `.rm` and `.rmSync` were added in [Node.js v14.14.0](https://nodejs.org/en/blog/release/v14.14.0/).

Although they [has been implemented in memfs](https://github.com/streamich/memfs/pull/754/files), they are not binded when calling `createFsFromVolume()`.

```ts
// Bind FS methods.
for (const method of fsSyncMethods) if (typeof vol[method] === 'function') fs[method] = vol[method].bind(vol);
for (const method of fsAsyncMethods) if (typeof vol[method] === 'function') fs[method] = vol[method].bind(vol);
```
https://github.com/streamich/memfs/blob/dd3828afa053af441d37e92a8d449f6782554458/src/index.ts#L38-L40

These methods are not in `fsSyncMethods` and `fsAsyncMethods` now.