### PR TITLE
fix: look for `exports.require` in `package.json` in addition to `main` when patching `require`

### DIFF
--- a/src/patchRequire.js
+++ b/src/patchRequire.js
@@ -113,7 +113,8 @@ export default function patchRequire(vol, unixifyPaths = false, Module = require
 
         let pkg;
         try {
-            pkg = packageMainCache[requestPath] = JSON.parse(json).main;
+            const pkgJson = JSON.parse(json);
+            pkg = packageMainCache[requestPath] = pkgJson.exports && pkgJson.exports.require || pkgJson.main;
         } catch (e) {
             e.path = jsonPath;
             e.message = 'Error parsing ' + jsonPath + ': ' + e.message;


### PR DESCRIPTION
ENV:
- run by nodejs
- memfs + unionfs
- `require('tiny-lru')`
  - version: 11.0.1
  - [package.json](https://github.com/avoidwork/tiny-lru/blob/master/package.json)

PACKAGE.JSON PART:
```json
{
  "main": "dist/tiny-lru",
  "exports": {
    "types": "./lru.d.ts",
    "import": "./dist/tiny-lru.js",
    "require": "./dist/tiny-lru.cjs"
  },
}
```

the `main` field is an ESModule，`require` need `exports.require` data to load module in CommonJS.
 